### PR TITLE
Avoid calling getId() twice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ class SessionMiddleware implements MiddlewareInterface
      */
     private function addCookieToResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $cookieValue = $this->session->getId() == '';
+        $cookieValue = $this->session->getId() ?? '';
         $cookieExpires = $cookieValue ? 1 : time() + $this->timeout;
 
         return $response->withAddedHeader(

--- a/README.md
+++ b/README.md
@@ -110,9 +110,8 @@ class SessionMiddleware implements MiddlewareInterface
      */
     private function addCookieToResponse(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
-        $wasDestroyed = is_null($this->session->getId());
-        $cookieValue = $wasDestroyed ? '' : $this->session->getId();
-        $cookieExpires = $wasDestroyed ? time() - 3600 : time() + $this->timeout;
+        $cookieValue = $this->session->getId() == '';
+        $cookieExpires = $cookieValue ? 1 : time() + $this->timeout;
 
         return $response->withAddedHeader(
              'Set-Cookie', $this->createCookieString($cookieValue, $cookieExpires, $request)


### PR DESCRIPTION
In the usage example from readme.

Use falsy '' as condition rather than bool $wasDestroyed. 
Don't calculate last hour when any non-null past value serves the same purpose.